### PR TITLE
fix(cli): run storybook in `development` env

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,10 @@ function _run () {
         mode
       })
     case 'dev':
+      // Make sure NODE_ENV is `development`.
+      // NOTE: While using `nuxt` to execute commands, Nuxt set NODE_END to `production` if it is missing.
+      // https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/setup.js#L9
+      process.env.NODE_ENV = 'development'
       return start({
         rootDir,
         mode

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ function _run () {
       })
     case 'dev':
       // Make sure NODE_ENV is `development`.
-      // NOTE: While using `nuxt` to execute commands, Nuxt set NODE_END to `production` if it is missing.
+      // NOTE: While using `nuxt` to execute commands, Nuxt set NODE_ENV to `production` if it is missing.
       // https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/setup.js#L9
       process.env.NODE_ENV = 'development'
       return start({


### PR DESCRIPTION
Make sure NODE_ENV is `development`.
**NOTE:** While using `nuxt` to execute commands, Nuxt set NODE_END to `production` if it is missing.

see: https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/setup.js#L9

Fix #38
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
