### PR TITLE
fix(storybook): escape win32 paths

### DIFF
--- a/storybook/index.js
+++ b/storybook/index.js
@@ -1,0 +1,11 @@
+import './mock'
+// helpers to fix windows path
+// https://github.com/nuxt/nuxt.js/blob/1edac29eba1a621339105f5adef73d4c30388fee/packages/utils/src/resolve.js#L13
+export const isWindows = process.platform.startsWith('win')
+
+export const wp = function wp (p = '') {
+  if (isWindows) {
+    return p.replace(/\\/g, '\\\\')
+  }
+  return p
+}

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,9 +1,10 @@
-/* Styles */<% if (Array.isArray(options.styles)) { %>
-<%= options.styles.map(s => `import '${s.replace(/\\/g, "\\\\")}'`).join("\n") %>
-<% } %>
 import Vue from 'vue'
+import { wp } from '~storybook';
+
+/* Styles */<% if (Array.isArray(options.styles)) { %>
+<%= options.styles.map(s => `import '${wp(s)}'`).join("\n") %>
+<% } %>
 import { normalizeError } from '~~/.nuxt-storybook/utils'
-import '~storybook/mock'
 <% if (options.store) { %>import { createStore } from '~~/.nuxt-storybook/store'<% } %>
 <% if (options.components) { %>import * as components from '~~/.nuxt-storybook/components';
 Object.keys(components).forEach(name => Vue.component(name, components[name]))<% } %>

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,5 +1,5 @@
 /* Styles */<% if (Array.isArray(options.styles)) { %>
-<%= options.styles.map(s => `import '${s}'`).join("\n") %>
+<%= options.styles.map(s => `import '${s.replace(/\\/g, "\\\\")}'`).join("\n") %>
 <% } %>
 import Vue from 'vue'
 import { normalizeError } from '~~/.nuxt-storybook/utils'
@@ -12,7 +12,7 @@ Object.keys(components).forEach(name => Vue.component(name, components[name]))<%
 <% }) %>
 
 
-const inject = (name, impl) => { 
+const inject = (name, impl) => {
   Vue.prototype['$' + name] = impl
 }
 <% if (options.store) {%>inject('store', createStore({}))<% }%>
@@ -26,4 +26,3 @@ Vue.prototype.app = {};<% /* prevent undefined app exception */ %>
     }
   }
 })
-  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

### Changes

Made sure that backslashes from win32 paths (still on that mighty quest) are escaped "twice" when interpolated through Lodash templates, not familiar with Lodash's templates so I'm not sure if this is the most effective way to do that (although it's apparently the same one which is used in [nuxt/utils](https://github.com/nuxt/nuxt.js/blob/1edac29eba1a621339105f5adef73d4c30388fee/packages/utils/src/resolve.js#L15)), feel free to correct me, but it's working still ^^'

### Explanation

Currently `@nuxtjs/storybook` does not work on platform using win32 paths (aKa Windows) because when `styles` array gets interpolated, win32 paths, after they got resolved (i.e. the `~/assets/css/tailwind.css` coming from `@nuxtjs/tailwindcss` module), needs to be escaped twice.
<details>
<summary>Current output at <code>./.nuxt-storybook/storybook/preview.js</code>, backslashes are not escaped</summary>
<br />

![image](https://user-images.githubusercontent.com/25330882/89666778-41b46400-d8db-11ea-8f68-64a5add1305c.png)
</details>

<details>
<summary>Server logs</summary>
<br />

![image](https://user-images.githubusercontent.com/25330882/89666846-5bee4200-d8db-11ea-9c55-998722962c8b.png)
</details>

If you need to reproduce just try to run this repository's Tailwind example on Windows 🙂
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->