### PR TITLE
fix(storybook): resolve nuxt aliases in globs

### DIFF
--- a/examples/manual-setup/storybook/main.js
+++ b/examples/manual-setup/storybook/main.js
@@ -1,6 +1,9 @@
 module.exports = {
   webpackFinal (config, options) {
     config = options.nuxtStorybookConfig.webpackFinal(config, options)
+    // extend config
     return config
-  }
+  },
+  stories: ['../components/**/*.stories.@(ts|js)'],
+  addons: []
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,23 +83,7 @@ async function buildNuxt (options: StorybookOptions) {
   // Load webpack config for Nuxt
   const { bundleBuilder } = nuxtBuilder
 
-  const nuxtStorybookConfig = Object.assign({
-    stories: [],
-    addons: []
-  }, nuxt.options.storybook)
-
-  nuxtStorybookConfig.configDir = path.resolve(options.rootDir, 'storybook')
-  if (!fsExtra.existsSync(path.resolve(options.rootDir, 'storybook'))) {
-    nuxtStorybookConfig.configDir = path.resolve(options.rootDir, '.nuxt-storybook', 'storybook')
-  }
-
-  nuxtStorybookConfig.stories = [
-    '~/components/**/*.stories.@(ts|js)',
-    ...nuxtStorybookConfig.stories
-  ].map(story => story
-    .replace(/^~~/, path.relative(nuxtStorybookConfig.configDir, nuxt.options.rootDir))
-    .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, nuxt.options.srcDir))
-  )
+  const nuxtStorybookConfig = nuxtStorybookOptions(nuxt.options)
 
   // generate files
   nuxt.hook('build:before', async () => {
@@ -165,7 +149,33 @@ export async function eject (options: StorybookOptions) {
     }
   })
 
-  const nuxtStorybookConfig = config.storybook || {}
+  const nuxtStorybookConfig = nuxtStorybookOptions(config)
   compileTemplate(path.resolve(templatesRoot, 'eject', 'main.js'), path.join(configDir, 'main.js'), nuxtStorybookConfig)
   compileTemplate(path.resolve(templatesRoot, 'eject', 'preview.js'), path.join(configDir, 'preview.js'), nuxtStorybookConfig)
+}
+
+function nuxtStorybookOptions (options) {
+  const nuxtStorybookConfig = Object.assign({
+    stories: [],
+    addons: []
+  }, options.storybook)
+
+  nuxtStorybookConfig.configDir = path.resolve(options.rootDir, 'storybook')
+  if (!fsExtra.existsSync(path.resolve(options.rootDir, 'storybook'))) {
+    nuxtStorybookConfig.configDir = path.resolve(options.rootDir, '.nuxt-storybook', 'storybook')
+  }
+
+  let srcDir = options.srcDir || options.rootDir
+  if (!srcDir.startsWith('/')) {
+    srcDir = path.resolve(options.rootDir, srcDir)
+  }
+  nuxtStorybookConfig.stories = [
+    '~/components/**/*.stories.@(ts|js)',
+    ...nuxtStorybookConfig.stories
+  ].map(story => story
+    .replace(/^~~/, path.relative(nuxtStorybookConfig.configDir, options.rootDir))
+    .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, srcDir))
+  )
+
+  return nuxtStorybookConfig
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,24 @@ async function buildNuxt (options: StorybookOptions) {
   // Load webpack config for Nuxt
   const { bundleBuilder } = nuxtBuilder
 
-  const nuxtStorybookConfig = nuxt.options.storybook || {}
+  const nuxtStorybookConfig = Object.assign({
+    stories: [],
+    addons: []
+  }, nuxt.options.storybook)
+
+  nuxtStorybookConfig.configDir = path.resolve(options.rootDir, 'storybook')
+  if (!fsExtra.existsSync(path.resolve(options.rootDir, 'storybook'))) {
+    nuxtStorybookConfig.configDir = path.resolve(options.rootDir, '.nuxt-storybook', 'storybook')
+  }
+
+  nuxtStorybookConfig.stories = [
+    '~/components/**/*.stories.@(ts|js)',
+    ...nuxtStorybookConfig.stories
+  ].map(story => story
+    .replace(/^~~/, path.relative(nuxtStorybookConfig.configDir, nuxt.options.rootDir))
+    .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, nuxt.options.srcDir))
+  )
+
   // generate files
   nuxt.hook('build:before', async () => {
     const plugins = await nuxtBuilder.normalizePlugins()
@@ -96,10 +113,6 @@ async function buildNuxt (options: StorybookOptions) {
     })
   })
 
-  nuxtStorybookConfig.configDir = path.resolve(options.rootDir, 'storybook')
-  if (!fsExtra.existsSync(path.resolve(options.rootDir, 'storybook'))) {
-    nuxtStorybookConfig.configDir = path.resolve(options.rootDir, '.nuxt-storybook', 'storybook')
-  }
   // Mock webpack build as we only need generated templates
   nuxtBuilder.bundleBuilder = {
     build () { }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,8 +1,5 @@
 export default {
   addons: [
     '@storybook/addon-actions/preset'
-  ],
-  stories: [
-    '~/components/**/*.stories.@(ts|js)'
   ]
 }

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,11 +1,7 @@
 module.exports = {
   webpackFinal(config, options) {
     return options.nuxtStorybookConfig.webpackFinal(config, options)
-  },
-<% if (Array.isArray(options.stories)) { %>
-  stories: [<%= options.stories.map(s => `'${s}'`).join(",") %>],
-<% } %>
-<% if (Array.isArray(options.addons)) { %>
-  addons: [<%= options.addons.map(s => `'${s}'`).join(",") %>],
-<% } %>
+  },<% if (options.stories.length) { %>
+  stories: [<%= options.stories.map(s => `'${s}'`).join(",") %>],<% } %><% if (options.addons.length) { %>
+  addons: [<%= options.addons.map(s => `'${s}'`).join(",") %>],<% } %>
 }


### PR DESCRIPTION
Starting v6, Storybook changes glob behavior and shows a warning when it can't find a story.
This happens because we use Nuxt aliases in the glob patterns.

close #75
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
