### PR TITLE
fix(storybook): normalize win32 paths for storybook globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-vue": "^2.0.2",
     "consola": "^2.15.0",
     "jiti": "^0.1.11",
-    "upath": "1.2.0"
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "latest",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "arg": "^4.1.3",
     "babel-preset-vue": "^2.0.2",
     "consola": "^2.15.0",
-    "jiti": "^0.1.11"
+    "jiti": "^0.1.11",
+    "upath": "1.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "latest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fsExtra from 'fs-extra'
+import upath from 'upath'
 import vueOptions from '@storybook/vue/dist/server/options'
 import { buildDev, buildStatic } from '@storybook/core/server'
 import { requireMaybeEdge, compileTemplate, logger } from './utils'
@@ -171,9 +172,9 @@ function nuxtStorybookOptions (options) {
   nuxtStorybookConfig.stories = [
     '~/components/**/*.stories.@(ts|js)',
     ...nuxtStorybookConfig.stories
-  ].map(story => story
+  ].map(story => upath.normalize(story
     .replace(/^~~/, path.relative(nuxtStorybookConfig.configDir, options.rootDir))
-    .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, srcDir))
+    .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, srcDir)))
   )
 
   return nuxtStorybookConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -14030,7 +14030,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@1.2.0, upath@^1.1.1, upath@^1.2.0:
+upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14030,7 +14030,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.1.1, upath@^1.2.0:
+upath@1.2.0, upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

### Changes
<!--- Describe your changes in detail -->
Added [upath](https://www.npmjs.com/package/upath) to normalize paths to POSIX specs (same strategy as here https://github.com/nuxt/nuxt.js/pull/7796) and used it when resolving glob patterns for `stories` array.

### Explanation
<!--- Why is this change required? What problem does it solve? -->
With `2.1.0`, generated `.nuxt-storybook/storybook/main.js` looks like this on Windows:
```javascript
module.exports = {
  webpackFinal(config, options) {
    return options.nuxtStorybookConfig.webpackFinal(config, options)
  },
  stories: ['..\../components/**/*.stories.@(ts|js)'],
}
```
The above is not a valid [glob pattern](https://www.npmjs.com/package/glob#glob-primer) and will lead to a fatal error while running Storybook. Since glob patterns are expected to use the POSIX separator this use upath to normalize them and will fix globs array:
```javascript
module.exports = {
  webpackFinal(config, options) {
    return options.nuxtStorybookConfig.webpackFinal(config, options)
  },
  stories: ['../../components/**/*.stories.@(ts|js)'],
}
```

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Let me know if you need further explanation, if you want me to fill a proper issue, or prefer another implementation 🙂

Cheers~

<img alt="win92" width="26" src="https://user-images.githubusercontent.com/25330882/90647932-321d0f80-e239-11ea-9259-21820616a71e.png" />

ps: I also checked/tested a bit for similar errors but found none, not sure what could be a more efficient strategy at ensuring things are win32 friendly in the long run 🤔
