### PR TITLE
fix(storybook): ensure default `components/` dir exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ function nuxtStorybookOptions (options) {
     srcDir = path.resolve(options.rootDir, srcDir)
   }
 
-  const storiesDir = path.resolve(options.rootDir, 'components/**/*.stories.@(ts|js)')
+  const storiesDir = path.resolve(options.srcDir, 'components')
   if (fsExtra.existsSync(storiesDir)) {
     nuxtStorybookConfig.stories.unshift('~/components/**/*.stories.@(ts|js)')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,10 +169,13 @@ function nuxtStorybookOptions (options) {
   if (!srcDir.startsWith('/')) {
     srcDir = path.resolve(options.rootDir, srcDir)
   }
-  nuxtStorybookConfig.stories = [
-    '~/components/**/*.stories.@(ts|js)',
-    ...nuxtStorybookConfig.stories
-  ].map(story => upath.normalize(story
+
+  const storiesDir = path.resolve(options.rootDir, 'components/**/*.stories.@(ts|js)')
+  if (fsExtra.existsSync(storiesDir)) {
+    nuxtStorybookConfig.stories.unshift('~/components/**/*.stories.@(ts|js)')
+  }
+
+  nuxtStorybookConfig.stories = nuxtStorybookConfig.stories.map(story => upath.normalize(story
     .replace(/^~~/, path.relative(nuxtStorybookConfig.configDir, options.rootDir))
     .replace(/^~/, path.relative(nuxtStorybookConfig.configDir, srcDir)))
   )


### PR DESCRIPTION
Ensure `components/` folder exists before pushing default stories path.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The `~/components/**/*.stories.@(ts|js)` path is forced and an error is thrown when missing. 

I'm using `@nuxtjs/storybook` to create docs for a nuxt module and I don't have a `components/` folder. In my `docs/` folder I just have a `nuxt.config.js`:

```js
import { join } from 'path'
import module from '..'

export default {
  components: true,
  buildModules: [module],
  storybook: {
    stories: [join(__dirname, '../lib/components/**/**.stories.js')]
  }
}
```
 
## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)