### PR TITLE
fix(storybook): resolve static dir relative to src dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ async function getStorybookConfig (options: StorybookOptions) {
   }
 
   if (!options.staticDir) {
-    options.staticDir = path.resolve(options.rootDir, nuxt.options.dir.static)
+    options.staticDir = path.resolve(nuxt.options.srcDir, nuxt.options.dir.static)
   }
   const staticDir = options.staticDir.split(',').map(dir => dir.trim())
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Static dirs are relative to srcDir of nuxt, Currently they are treats as rootDir relatives
close #106

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
