### PR TITLE
fix(storybook): Allow nuxt-link mock to take an Object for the to prop

### DIFF
--- a/storybook/mock/nuxt-link.js
+++ b/storybook/mock/nuxt-link.js
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions'
 Vue.component('NuxtLink', {
   props: {
     to: {
-      type: String,
+      type: [String, Object],
       required: true
     }
   },


### PR DESCRIPTION
Adjusted the Proptype for the nuxt-link mock

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Nuxt Storybook gives errors in console.log when you pass an Object to the to prop (which is allowed and common ). 

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
No tests as it's a very minor change and none of the existing test cases cover it.
