### PR TITLE
fix: inject `$i18n` in Vue prototype

### DIFF
--- a/storybook/nuxt-entry.js
+++ b/storybook/nuxt-entry.js
@@ -189,6 +189,13 @@ export async function getNuxtApp() {
         // Make sure plugin scripts executes before `../index.js` import
         const { app } = await createApp(null, __NUXT__.config)
         window.__NUXT_APP = app;
+        Vue.mixin({
+          computed: {
+            $i18n: {
+              get: function () { return app.i18n },
+            }
+          }
+        })
     }
     return window.__NUXT_APP;
 }
@@ -196,13 +203,13 @@ export async function getNuxtApp() {
 
 // based on: https://github.com/storybookjs/storybook/blob/master/addons/docs/src/frameworks/vue/prepareForInline.ts
 export function prepareForInline (storyFn, { args }) {
-  const component = storyFn()
   const el = React.useRef(null)
   // FIXME: This recreates the Vue instance every time, which should be optimized
   React.useEffect(() => {
     let root
     const __NUXT_APP = getNuxtApp()
     __NUXT_APP.then((app) => {
+      const component = storyFn()
       root = new Vue({
         ...app,
         el: el.current,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Create a computed mixin for `$i18n` to prevent `undefined` error
fix #149

@rchl What do you think, I found that `$i18n` found `undefined` in component context. Do you know a workaround instead of this mixin?

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
