### PR TITLE
fix(module): move aliases to preset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,8 @@ async function getStorybookConfig (options: StorybookOptions) {
     ...options,
     staticDir,
     frameworkPresets: [
-      ...vueOptions.frameworkPresets,
-      require.resolve('./preset')
+      require.resolve('./preset'),
+      ...vueOptions.frameworkPresets
     ]
   }
 }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,3 +1,18 @@
+import path from 'path'
+import * as webpack from 'webpack'
+import { WebpackExtras } from './types'
+
 export default {
-  addons: []
+  webpackFinal (config: webpack.Configuration, extras: WebpackExtras): webpack.Configuration {
+    // Aliases
+    const buildDir = extras.nuxt.options.buildDir
+    config.resolve.alias = {
+      ...extras.nuxtWebpackConfig.resolve.alias,
+      ...config.resolve.alias,
+      '~storybook': path.resolve(__dirname, '../storybook'),
+      // Nuxt plugins alias
+      ...extras.nuxtBuilder.plugins.reduce((map, plugin) => ({ ...map, [plugin.name]: path.resolve(buildDir, plugin.src) }), {})
+    }
+    return config
+  }
 }

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import * as webpack from 'webpack'
 import { WebpackExtras } from './types'
 
@@ -46,16 +45,6 @@ export function getWebpackConfig (config: webpack.Configuration, extras: Webpack
     ...rules,
     ...extras.nuxtWebpackConfig.module.rules
   ]
-
-  // Aliases
-  const buildDir = extras.nuxt.options.buildDir
-  config.resolve.alias = {
-    ...extras.nuxtWebpackConfig.resolve.alias,
-    ...config.resolve.alias,
-    '~storybook': path.resolve(__dirname, '../storybook'),
-    // Nuxt plugins alias
-    ...extras.nuxtBuilder.plugins.reduce((map, plugin) => ({ ...map, [plugin.name]: path.resolve(buildDir, plugin.src) }), {})
-  }
 
   // Return the altered config
   return config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Because storybook run presets before `main.js`, the aliases are not available in addons.

close #152


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
