### PR TITLE
test: enable windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,16 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v1
 
+      - name: cache example dependenies
+        id: cache-example
+        uses: actions/cache@v2
+        with:
+          path: examples/manual-setup/node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, 'examples/manual-setup/node_modules/package.json')) }}
+
       - name: Example install dependencies
         working-directory: examples/manual-setup
+        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
       - name: Example build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest]
         node: [12]
 
     steps:
@@ -44,3 +44,11 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v1
+
+      - name: Example install dependencies
+        working-directory: examples/manual-setup
+        run: yarn
+
+      - name: Example build
+        working-directory: examples/manual-setup
+        run: yarn storybook:build

--- a/examples/manual-setup/package.json
+++ b/examples/manual-setup/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "serve": "nuxt-storybook",
+    "serve": "nuxt storybook",
+    "storybook:build": "nuxt storybook build",
     "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest"
   },
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The `nuxt-storybook build` in a project fails under Windows, so to illustrate the issue, I've added a GitHub Actions CI test coverage to show a reproducible example. Other than pointing out the issue, I'd also suggest for you to explicitly add (all the) other examples to some test, because at the moment they aren't covered at all, which causes false expectations of the latest release being stable. Please iterate upon this commit before merging, as I only covered one example (and without CI caching).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Introducing existing bug to test coverage

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The `nuxt-storybook build` doesn't seem to work under Windows, as it fails with the following error:

```
info => Cleaning outputDir D:\a\storybook\storybook\examples\manual-setup\storybook-static
ERR! Error: no such directory to load static files: D:\a\storybook\storybook\examples\manual-setup\D
[fatal] Failed to run command `nuxt-storybook`:
Error: Command failed with exit code 4294967295: nuxt-storybook build
```

There's also another issue there (which doesn't directly seem to cause this error), which also occurs during `nuxt storybook`: the static files directory becomes `D` instead of `storybook-static` (or `C` if the drive is `C:\`) even if there's no command switch provided; if such a directory exists, then it's used. Adding an explicit `--static-dir storybook-static` "solves" that issue, but the build still fails. (Btw. it would be great if you could mention some dev documentation in the future explaining how we could debug these issues and contribute directly.) 

---

I'll also take this opportunity to quickly mention a few **off-topic** concerns from a perspective of a new storybook user, which I'd hope can be addressed in the documentation, just as a suggestion:
* vuetify example seems missing in the docs (where it could use some additional explanation for any workarounds (probably for treeShaking), as the only other vuetify-storybook example that I could find is very obsolete without any hints about replacement)
* storybook mentions JSX/TSX support, but the current state of this not being supported by Vue isn't reflected anywhere, except implicitly by examples
* it seems confusing why .stories.js are only detected under components directory by default, and not under stories, so for people who prefer opinionated zero-config, is this really a best practice? (Plus why isn't .ts and .mdx also supported by default?)
* does Nuxt always automatically import our components even in stories, so that no import is ever necessary? Sometimes the examples use the tags in a string directly, and sometimes there's an import used in both component and components fields within a single file, which seems to work even without them. (Though I can't imagine .mdx usage of `Props of` without import; which also doesn't seem to be supported in other types.) Maybe this is ["to use auto-detected controls with Vue"](https://storybook.js.org/docs/vue/essentials/controls#choosing-the-control-type), is there (or will there be) a way to avoid this? Could the args/argTypes/props usage with this module be documented explicitly to provide an opinionated quick start? Maybe the `Nuxt components support` on the home page could use some elaboration.
* is `nuxt storybook` the same as `nuxt-ts storybook`? Plus the manual-setup uses `nuxt-storybook` unlike other examples, is it on purpose?
* are there any eslint rules that we should install by default (or are they included as zero-config), for example [for MDX type](https://github.com/mdx-js/eslint-mdx)? It would be perfect if this also included recommendations for VS Code extensions, prettier rules, linter script(s) for CI (remark-lint for MDX?), TS example (including typing the story itself, `{ Story } from '@storybook/vue'`, to provide documentation within IDE), etc.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
