### PR TITLE
docs: update README (remove .nuxtignore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,7 @@ npm install --save-dev @nuxtjs/storybook
 storybook-static
 ```
 
-3. Add `**/*.stories.js` to `.nuxtignore`
-
-```bash{}[.nuxtignore]
-**/*.stories.js
-```
-
-4. Start adding [stories](https://storybook.nuxtjs.org/usage)
+3. Start adding [stories](https://storybook.nuxtjs.org/usage)
 
 ## Configure
 


### PR DESCRIPTION
During #23 the .nuxtignore entry was added in 670ea295f09aeede3decbc1552cf6e2e6bc0fbce but later removed from setup.md in 557c56b9c13df34e246668db6a4bf1b60b8116d8 (PR #96) after the nuxt/components has implemented this directly.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Keeping this in README was probably just an oversight as seen by the issue development. I randomly noticed this discrepancy by searching if there's any mention about this .nuxtignore entry and what are its consequences, as it seemed to be quite a project bloating with zero configuration.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
