### PR TITLE
fix: prevent rendering outside of nuxt context

### DIFF
--- a/storybook/nuxt-entry.js
+++ b/storybook/nuxt-entry.js
@@ -62,6 +62,9 @@ function prepare (
     [VALUES]: { ...(innerStory ? innerStory.options[VALUES] : {}), ...extractProps(story) },
     functional: true,
     render (h, { data, parent, children }) {
+      // Suddenly story will render twice and in the first render it isn't descendent of nuxt app
+      // Ensure that story will render only inside the nuxt context 
+      if (!parent.$root.nuxt) return null
       return h(
         story,
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Suddenly stories are rendered twice and in the first render, they are not a descendent of the Nuxt app. 
This PR changes the render function to return `null` if the story wants to render outside of the Nuxt context. 

close #190 #193

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
