### PR TITLE
fix(plugins): execute plugin scripts before imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nuxt/typescript-build": "latest",
     "@nuxt/typescript-runtime": "latest",
     "@nuxtjs/axios": "^5.13.1",
+    "@nuxtjs/color-mode": "^2.0.3",
     "@nuxtjs/eslint-config-typescript": "latest",
     "@nuxtjs/fontawesome": "^1.1.2",
     "@nuxtjs/proxy": "^2.1.0",

--- a/playground/nuxt.config.js
+++ b/playground/nuxt.config.js
@@ -4,7 +4,8 @@ export default {
     '~/assets/styles/main.scss'
   ],
   buildModules: [
-    '@nuxtjs/fontawesome'
+    '@nuxtjs/fontawesome',
+    '@nuxtjs/color-mode'
   ],
   modules: [
     '@nuxtjs/axios',

--- a/storybook/nuxt-entry.js
+++ b/storybook/nuxt-entry.js
@@ -6,7 +6,6 @@ import fetch from 'unfetch'
 import '@storybook/vue/dist/client/preview/globals'
 import { extractProps } from '@storybook/vue/dist/client/preview/util'
 import fetchMixin from '../mixins/fetch.client'
-import { createApp } from '../'
 
 /**
  * @nuxtjs/storybook
@@ -14,6 +13,13 @@ import { createApp } from '../'
  */
 window.__NUXT__ = { config: <%= JSON.stringify(options.nuxtOptions.publicRuntimeConfig || {}) %> };
 <%= options.nuxtOptions.head.script.map(s => s.innerHTML).join(";\n") %>
+
+/**
+ * Important: Import `createApp` after plugin scripts
+ * This is required because some plugins (like color-mode) uses global scripts on import
+ * link: https://github.com/nuxt-community/color-mode-module/blob/master/lib/templates/plugin.client.js#L7
+ */
+const { createApp } = require('../')
 
 // Fetch mixin
 if (!Vue.__nuxt__fetch__mixin__) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,6 +1719,14 @@
     consola "^2.15.3"
     defu "^3.2.2"
 
+"@nuxtjs/color-mode@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/color-mode/-/color-mode-2.0.3.tgz#6ba5ab0a6364c966b48386867f2660bf0dcd7b5d"
+  integrity sha512-yfTkUbXcq42YW7qCv66kqAttnjr+sLpxY+HIJq7nlLadDQeEyjl+QMR8AHKS2KQMVfMwd7rbJyE+jU2PKjwDcQ==
+  dependencies:
+    defu "^3.2.2"
+    lodash.template "^4.5.0"
+
 "@nuxtjs/eslint-config-typescript@latest":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-5.0.0.tgz#060c1402e559b1df78c8c19b2f5a873eac53cab2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Import plugins after plugin scripts. 
Originally reported in: https://github.com/nuxt-community/color-mode-module/issues/69

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
