### PR TITLE
fix: Make sure to ignore all Nuxt server plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,16 +8,16 @@ import { StorybookOptions } from './types'
 import { getWebpackConfig } from './webpack'
 import middlewares from './runtime/middlewares'
 
-export async function build(options: StorybookOptions) {
+export async function build (options: StorybookOptions) {
   const buildOptions = await getStorybookConfig(options)
   buildStatic(buildOptions)
 }
-export async function start(options: StorybookOptions) {
+export async function start (options: StorybookOptions) {
   const buildOptions = await getStorybookConfig(options)
   buildDev(buildOptions)
 }
 
-async function getStorybookConfig(options: StorybookOptions) {
+async function getStorybookConfig (options: StorybookOptions) {
   const {
     nuxt,
     nuxtBuilder,
@@ -74,7 +74,7 @@ async function getStorybookConfig(options: StorybookOptions) {
   }
 }
 
-async function buildNuxt(options: StorybookOptions) {
+async function buildNuxt (options: StorybookOptions) {
   ensureCoreJs3(options.rootDir)
   const buildDir = path.resolve(options.rootDir, '.nuxt-storybook')
   const { loadNuxt, getBuilder } = requireMaybeEdge('nuxt')
@@ -151,7 +151,7 @@ async function buildNuxt(options: StorybookOptions) {
 
   // Mock webpack build as we only need generated templates
   nuxtBuilder.bundleBuilder = {
-    build() { }
+    build () { }
   }
   await nuxtBuilder.build()
 
@@ -173,7 +173,7 @@ async function buildNuxt(options: StorybookOptions) {
   }
 }
 
-function generateStorybookFiles(options) {
+function generateStorybookFiles (options) {
   const templatesRoot = path.resolve(__dirname, '../storybook')
   this.addTemplate({
     src: path.resolve(templatesRoot, 'main.js'),
@@ -202,7 +202,7 @@ function generateStorybookFiles(options) {
   })
 }
 
-export function eject(options: StorybookOptions) {
+export function eject (options: StorybookOptions) {
   const configDir = path.resolve(options.rootDir, '.storybook')
   const templatesRoot = path.resolve(__dirname, '../storybook')
   if (!options.force && fsExtra.existsSync(configDir)) {
@@ -214,7 +214,7 @@ export function eject(options: StorybookOptions) {
   compileTemplate(path.resolve(templatesRoot, 'eject', 'preview.js'), path.join(configDir, 'preview.js'), {})
 }
 
-async function nuxtStorybookOptions(nuxt, options) {
+async function nuxtStorybookOptions (nuxt, options) {
   const nuxtStorybookConfig = Object.assign({
     stories: [],
     addons: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,16 +8,16 @@ import { StorybookOptions } from './types'
 import { getWebpackConfig } from './webpack'
 import middlewares from './runtime/middlewares'
 
-export async function build (options: StorybookOptions) {
+export async function build(options: StorybookOptions) {
   const buildOptions = await getStorybookConfig(options)
   buildStatic(buildOptions)
 }
-export async function start (options: StorybookOptions) {
+export async function start(options: StorybookOptions) {
   const buildOptions = await getStorybookConfig(options)
   buildDev(buildOptions)
 }
 
-async function getStorybookConfig (options: StorybookOptions) {
+async function getStorybookConfig(options: StorybookOptions) {
   const {
     nuxt,
     nuxtBuilder,
@@ -74,7 +74,7 @@ async function getStorybookConfig (options: StorybookOptions) {
   }
 }
 
-async function buildNuxt (options: StorybookOptions) {
+async function buildNuxt(options: StorybookOptions) {
   ensureCoreJs3(options.rootDir)
   const buildDir = path.resolve(options.rootDir, '.nuxt-storybook')
   const { loadNuxt, getBuilder } = requireMaybeEdge('nuxt')
@@ -121,7 +121,7 @@ async function buildNuxt (options: StorybookOptions) {
       src = plugin.src
     }
 
-    if (typeof src === 'string' && src.match(/\.server\.(ts|js)/)) {
+    if (typeof src === 'string' && src.match(/\.server\.?(.*)\.(ts|js)/)) {
       return false
     }
 
@@ -151,7 +151,7 @@ async function buildNuxt (options: StorybookOptions) {
 
   // Mock webpack build as we only need generated templates
   nuxtBuilder.bundleBuilder = {
-    build () { }
+    build() { }
   }
   await nuxtBuilder.build()
 
@@ -173,7 +173,7 @@ async function buildNuxt (options: StorybookOptions) {
   }
 }
 
-function generateStorybookFiles (options) {
+function generateStorybookFiles(options) {
   const templatesRoot = path.resolve(__dirname, '../storybook')
   this.addTemplate({
     src: path.resolve(templatesRoot, 'main.js'),
@@ -202,7 +202,7 @@ function generateStorybookFiles (options) {
   })
 }
 
-export function eject (options: StorybookOptions) {
+export function eject(options: StorybookOptions) {
   const configDir = path.resolve(options.rootDir, '.storybook')
   const templatesRoot = path.resolve(__dirname, '../storybook')
   if (!options.force && fsExtra.existsSync(configDir)) {
@@ -214,7 +214,7 @@ export function eject (options: StorybookOptions) {
   compileTemplate(path.resolve(templatesRoot, 'eject', 'preview.js'), path.join(configDir, 'preview.js'), {})
 }
 
-async function nuxtStorybookOptions (nuxt, options) {
+async function nuxtStorybookOptions(nuxt, options) {
   const nuxtStorybookConfig = Object.assign({
     stories: [],
     addons: [],


### PR DESCRIPTION
As it turns out some server plugins are still copied over to the .nuxt-storybook folder after #290 was merged. The regex doesn't match all filenames.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Some server plugins are not copied over to the .nuxt-storybook folder after #290 was merged. The regex doesn't match all filenames. I encountered files names such as: `/Users/timbenniks/Websites/timbenniks-vnext/.nuxt-storybook/lib.intent-manifest-fetcher-plugin.server.99303334.js`

The regex in #290 expects `server.js`. I have added a more flexible pattern: `\.server\.?(.*)\.(ts|js)`.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
