### PR TITLE
fix: missing handler in server middleware

### DIFF
--- a/storybook/middleware.js
+++ b/storybook/middleware.js
@@ -21,7 +21,11 @@ module.exports = function (app) {
       _handler = _handler.default || _handler
     }
 
-    app.use(_route, _handler)
+    if (_handler) {
+      app.use(_route, _handler)
+    } else {
+      console.log(`[nuxt-storybook] Middleware ${middleware} has no handler`)
+    }
   }
 
   middlewares.forEach(m => addServerMiddleware(m))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

In the context of building storybook in bridge, I got an empty server middleware object for some reason (not sure why). This then lead to `_handler` being undefined and thus `app.use` throws an error.
As a quick fix, I've added an if check to test if `_handler` is defined before calling `app.use`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
