### PR TITLE
fix: create dummy package.json for ESM compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,11 @@ function generateStorybookFiles (options) {
     fileName: path.join('storybook', 'nuxt-entry.js'),
     options
   })
+  this.addTemplate({
+    src: path.resolve(templatesRoot, 'package-template.json'),
+    fileName: path.join('storybook', 'package.json'),
+    options
+  })
 }
 
 export function eject (options: StorybookOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,7 @@ function generateStorybookFiles (options) {
     fileName: path.join('storybook', 'nuxt-entry.js'),
     options
   })
+  // Dummy package.json is needed for workaround https://github.com/storybookjs/storybook/issues/11587
   this.addTemplate({
     src: path.resolve(templatesRoot, 'package-template.json'),
     fileName: path.join('storybook', 'package.json'),

--- a/storybook/package-template.json
+++ b/storybook/package-template.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
If you have `type: module` in your main `package.json`, then storybook doesn't work. This is not an issue with the nuxt module, but with upstream storybook, see https://github.com/storybookjs/storybook/issues/11587. 
In this issue, a workaround is outlined which involves creating a `package.json` in the `storybook` folder.
This is added with this PR.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
