### PR TITLE
docs: remove `postcss` from install script

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -7,11 +7,11 @@ Add `@nuxtjs/storybook` dependency to your project:
 <code-group>
 
   ```bash [Yarn]
-  yarn add --dev @nuxtjs/storybook postcss@latest
+  yarn add --dev @nuxtjs/storybook
   ```
 
   ```bash [NPM]
-  npm install --save-dev @nuxtjs/storybook postcss@latest
+  npm install --save-dev @nuxtjs/storybook
   ```
 
 </code-group>


### PR DESCRIPTION
Remove postcss as a getting started requirement

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Remove unneeded postcss dependency to be installed to get started as documented on the getting started docs page

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
