### PR TITLE
feat(cli): Support chromatic's `--webpack-stats-json` flag

### DIFF
--- a/docs/content/1.getting-started/3.commands.md
+++ b/docs/content/1.getting-started/3.commands.md
@@ -35,7 +35,7 @@ Development command have some options you can pass to alter storybook behaviors.
 --smoke-test                  Exit after successful start
 --ci                          CI mode (skip interactive prompts, don't open browser)
 --quiet                       Suppress verbose build output
---tsconfig <file-path>        Specify tha path to tsconfig.json file.
+--tsconfig <file-path>        Specify the path to tsconfig.json file.
 ```
 
 ## Export
@@ -64,6 +64,8 @@ Build command have some options you can pass to alter storybook behaviors.
 -o, --output-dir [dir-name]   Directory where to store built files
 --tsconfig <file-path>        Specify tha path to tsconfig.json file.
 --quiet
+--webpack-stats-json <file-path> Must be set to the value of --output-dir, for
+use with Chromatic's TurboSnap feature
 ```
 
 ## Eject

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,8 @@ function _run () {
     '-h': '--host',
     '--force': Boolean,
     '--tsconfig': String,
-    '--no-manager-cache': Boolean
+    '--no-manager-cache': Boolean,
+    '--webpack-stats-json': String
   })
   const { _, ...flags } = args
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,4 +20,5 @@ export interface StorybookOptions {
   port?: Number;
   host?: String;
   force?: boolean;
+  webpackStatsJson?: string;
 }


### PR DESCRIPTION
Adds support for the `--webpack-stats-json` flag so Chromatic can pass it through successfully and Nuxt Storybook can be used to publish to Chromatic with TurboSnap enabled.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
[Chromatic](https://www.chromatic.com/), a cloud-based tool used to publish Storybook instances and facilitate UI review, has a feature called [TurboSnap](https://www.chromatic.com/docs/turbosnap) which allows smart snapshotting for visual regression testing.  When publishing Storybook using the Chromatic CLI and the `--only-changed` flag to activate TurboSnap, it calls `build-storybook` and attempts to pass the `--webpack-stats-json` flag automatically, which causes the command to fail and prevents using TurboSnap with Nuxt Storybook.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
