### PR TITLE
fix: `undefined` render args argument

### DIFF
--- a/storybook/nuxt-entry.js
+++ b/storybook/nuxt-entry.js
@@ -69,7 +69,7 @@ function prepare (
     functional: true,
     render (h, { data, parent, children }) {
       // Suddenly story will render twice and in the first render it isn't descendent of nuxt app
-      // Ensure that story will render only inside the nuxt context 
+      // Ensure that story will render only inside the nuxt context
       if (!parent.$root.nuxt) return null
       return h(
         story,
@@ -132,7 +132,7 @@ export async function render({
   storyFn,
   kind,
   name,
-  args,
+  storyContext: { args },
   showMain,
   showError,
   showException,
@@ -141,7 +141,7 @@ export async function render({
   if (!root) {
     const app = await getNuxtApp();
 
-    root = new Vue({  
+    root = new Vue({
       ...app,
       data() {
         return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Since version 4.3.0, args/controls don't work (#373). That's because the argument passed to the render function does not have any `args` object passed to it (it's always undefined). The `args` are now available in the `storyContext` object that is passed to the render function.
This is already used in storybook's [latest vue render function](https://github.com/storybookjs/storybook/blob/7ffc089ca285da0f2e7a68af4d36592e149f715d/app/vue/src/client/preview/render.ts#L63)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
