### PR TITLE
fix: keep `NODE_ENV` set by users

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ function _run () {
       // Make sure NODE_ENV is `development`.
       // NOTE: While using `nuxt` to execute commands, Nuxt set NODE_ENV to `production` if it is missing.
       // https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/setup.js#L9
-      process.env.NODE_ENV = 'development'
+      process.env.NODE_ENV = process.env.NODE_ENV || 'development'
       return start({
         rootDir,
         mode,


### PR DESCRIPTION
Don't override the `NODE_ENV` if it's already set.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
When runnnig storybook, I need to use special setting in my `nuxt.config.js`. I tried to set `NODE_ENV` to any value (`storybook` for example), but the module would always override it.

## Checklist:
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I think this should be the default behavior and would not require test or documentation.
