### PR TITLE
Bugfix: `postcss@8` is now a mandatory dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@
 
 ```bash
 #using yarn
-yarn add --dev @nuxtjs/storybook
+yarn add --dev @nuxtjs/storybook postcss@8
 # using npm
-npm install --save-dev @nuxtjs/storybook
+npm install --save-dev @nuxtjs/storybook postcss@8
 ```
 
 


### PR DESCRIPTION
https://github.com/nuxt-community/storybook/issues/381

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (a non-breaking change which fixes an issue)
- [  ] New feature (a non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
Adds PostCSS version 8 as a dependency when installing @nuxtjs/storybook

<!--- Why is this change required? What problem does it solve? -->
 PostCSS version 8 needs to be installed alongside `@nuxtjs/storybook` or the project breaks when running `yarn dev`.

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
https://github.com/nuxt-community/storybook/issues/381

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my changes (if not applicable, please state why)

I've tested it in a clean Nuxt.js install, after installing the `druxt` npm module. Now I can run `yarn dev` or `yarn nuxt storybook` without throwing errors and ending unexpectedly.
