### PR TITLE
fix: include plugins with `mode: 'all'`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ async function buildNuxt (options: StorybookOptions) {
    */
   nuxt.options.plugins = nuxt.options.plugins.filter((plugin) => {
     if (typeof plugin === 'object') {
-      return !plugin.mode || plugin.mode === 'client'
+      return !plugin.mode || plugin.mode === 'client' || plugin.mode === 'all'
     }
 
     if (typeof plugin === 'string' && plugin.match(/\.server\.?(.*)\.(ts|js)/)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves #359. With bridge, we need some compatibility plugins to run in order to support new API such as `useNuxtApp()`. These plugins are currently being filtered because their mode is (newly unhandled) `all`. This PR avoid filtering them out.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
